### PR TITLE
feat: extend supported temperature range down to 10°C

### DIFF
--- a/aio_intex_spa/intex_spa_query.py
+++ b/aio_intex_spa/intex_spa_query.py
@@ -93,7 +93,7 @@ class IntexSpaQuery:
 
         self.request: str = COMMAND[intent]["request"]
         if intent == "preset_temp":
-            self.request = self.request + hex(preset_temp)[2:].upper()
+            self.request = self.request + hex(preset_temp)[2:].upper().zfill(2)
 
         self.type: int = COMMAND[intent]["type"]
 

--- a/aio_intex_spa/intex_spa_query.py
+++ b/aio_intex_spa/intex_spa_query.py
@@ -93,7 +93,7 @@ class IntexSpaQuery:
 
         self.request: str = COMMAND[intent]["request"]
         if intent == "preset_temp":
-            self.request = self.request + hex(preset_temp)[2:].upper().zfill(2)
+            self.request = self.request + format(preset_temp, "02X")
 
         self.type: int = COMMAND[intent]["type"]
 

--- a/examples/intex_spa_set_preset_temp_10.py
+++ b/examples/intex_spa_set_preset_temp_10.py
@@ -1,0 +1,21 @@
+"""Usage example: Set spa preset temp to 10°C."""
+
+import os
+import logging
+import asyncio
+
+from aio_intex_spa import IntexSpa
+
+SPA_ADDRESS = os.getenv("SPA_ADDRESS") or "SPA_DEVICE"
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+async def set_spa_preset_temp_10():
+    """Set spa preset temp to 10°C."""
+    spa = IntexSpa(SPA_ADDRESS)
+
+    print(await spa.async_set_preset_temp(10))
+
+
+asyncio.run(set_spa_preset_temp_10())


### PR DESCRIPTION
## Summary

Extends the minimum supported target temperature from 16°C down to 10°C.

## Motivation

All wifi-enabled Intex spa models supported by this library (SB-HWF20, SB-HSWF20, SC-WF20, SC-WF20-1) have an official temperature adjustment range of 10–40°C per their manuals. The previous lower bound of 16°C does not correspond to any supported hardware and appears to originate from older non-wifi models.

## Changes

This change adds support for temperatures down to 10°C. 

Temperatures between 10°C and 15°C were set with one digit HEX values A to F. They are now prefixed with a 0 to length 2 as required. 

## Testing

Added example intex_spa_set_preset_temp_10.py to try it out.